### PR TITLE
Orgnr validated as personnr

### DIFF
--- a/Paytrim.ValidationHelper.Tests/OrganisationsnummerTests.cs
+++ b/Paytrim.ValidationHelper.Tests/OrganisationsnummerTests.cs
@@ -33,6 +33,8 @@ namespace Paytrim.ValidationHelper.Tests
         [Theory]
         [InlineData("5560360793", true)]
         [InlineData("5560360792", false)]
+        [InlineData("1010101010", true)]
+        [InlineData("1010101011", false)]
         [InlineData(" 556036-0793 ", true)]
         public void OrganisationsnummerTryParse_ShouldReturn(string organisationsnummer, bool isOk)
         {

--- a/Paytrim.ValidationHelper/Organisationsnummer.cs
+++ b/Paytrim.ValidationHelper/Organisationsnummer.cs
@@ -21,7 +21,7 @@ namespace Paytrim.ValidationHelper
                 var onlyNumbers = new string(organisationsnummer.Where(c => c >= '0' && c <= '9').ToArray());
                 Parse(onlyNumbers);
             }
-            catch(Exception)
+            catch (Exception)
             {
                 return false;
             }
@@ -41,9 +41,12 @@ namespace Paytrim.ValidationHelper
                 throw new ApplicationException($"'{organisationsnummer}' is not formated correctly (yymmddnnnn or nnnnnn(-)nnnn)");
             }
 
-            if(int.Parse(organisationsnummer.Substring(2, 1)) <= 1)
+            if (int.Parse(organisationsnummer.Substring(2, 1)) <= 1)
             {
-                Personnummer.TryParse(organisationsnummer);
+                if (!Personnummer.TryParse(organisationsnummer))
+                {
+                    throw new ApplicationException($"'{organisationsnummer}' is not valid");
+                }
             }
             else
             {

--- a/Paytrim.ValidationHelper/Paytrim.ValidationHelper.csproj
+++ b/Paytrim.ValidationHelper/Paytrim.ValidationHelper.csproj
@@ -11,7 +11,7 @@
     <PackageLicenseFile></PackageLicenseFile>
     <AssemblyVersion>1.0.1.0</AssemblyVersion>
     <FileVersion>1.0.1.0</FileVersion>
-    <Version>1.0.3.2</Version>
+    <Version>1.0.3.3</Version>
     <PackageProjectUrl>https://github.com/Paytrim/Paytrim.ValidationHelper</PackageProjectUrl>
     <RepositoryUrl>https://github.com/Paytrim/Paytrim.ValidationHelper</RepositoryUrl>
     <PackageTags>kontonummer organisationsnummer personnummer bank accountnumber swedish validate parse</PackageTags>

--- a/Paytrim.ValidationHelper/Paytrim.ValidationHelper.csproj
+++ b/Paytrim.ValidationHelper/Paytrim.ValidationHelper.csproj
@@ -11,7 +11,7 @@
     <PackageLicenseFile></PackageLicenseFile>
     <AssemblyVersion>1.0.1.0</AssemblyVersion>
     <FileVersion>1.0.1.0</FileVersion>
-    <Version>1.0.3.1</Version>
+    <Version>1.0.3.2</Version>
     <PackageProjectUrl>https://github.com/Paytrim/Paytrim.ValidationHelper</PackageProjectUrl>
     <RepositoryUrl>https://github.com/Paytrim/Paytrim.ValidationHelper</RepositoryUrl>
     <PackageTags>kontonummer organisationsnummer personnummer bank accountnumber swedish validate parse</PackageTags>

--- a/Paytrim.ValidationHelper/Personnummer.cs
+++ b/Paytrim.ValidationHelper/Personnummer.cs
@@ -28,7 +28,7 @@ namespace Paytrim.ValidationHelper
                 var onlyNumbers = new string(personnummer.Where(c => c >= '0' && c <= '9').ToArray());
                 Parse(onlyNumbers, out _, out _);
             }
-            catch(Exception)
+            catch (Exception)
             {
                 return false;
             }
@@ -39,6 +39,27 @@ namespace Paytrim.ValidationHelper
         public override string ToString()
         {
             return _personnummer;
+        }
+
+        public string ToString(int length)
+        {
+            if (length < 10 || length > 13)
+            {
+                throw new ApplicationException("Use length 10-13 for different formats of '(cc)yymmdd(-)nnnn'");
+            }
+            var yearMonth = length switch
+            {
+                10 or 11 => _dateOfBirth.ToString("yyMM"),
+                _ => _dateOfBirth.ToString("yyyyMM"),
+            };
+            var day = (IsSamordningsnummer ? _dateOfBirth.Day + 60 : _dateOfBirth.Day).ToString("00");
+            var separator = length switch
+            {
+                10 or 12 => string.Empty,
+                _ => (DateTime.UtcNow.AddYears(-100).Year < _dateOfBirth.Year) ? "-" : "+"
+            };
+            var number = _personnummer[^4..];
+            return $"{yearMonth}{day}{separator}{number}";
         }
 
         private static void Parse(string personnummer, out DateTime dateOfBirth, out bool isSamordningsnummer)


### PR DESCRIPTION
Lite autoformatering gör det svårare att se skillnaden, den viktiga skillnaden är att returvärdet från Personnummer.TryParse(organisationsnummer); kontrolleras